### PR TITLE
chore: add package info to release artifactfeat

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
               run: |
                   mkdir -p comicreader.koplugin
                   cp -r src comicreader.koplugin/src
-                  cp main.lua _meta.lua comicreader.koplugin/
+                  cp version.txt CHANGELOG.md README.md main.lua _meta.lua comicreader.koplugin/
                   cp -r extra-plugins/statistics.koplugin .
                   zip -r comicreader.koplugin.zip comicreader.koplugin statistics.koplugin -i '*.lua'
             - name: Upload Release Artifact

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
-    "prerelease": true,
+    "prerelease": false,
     "prerelease-type": "beta",
     "release-type": "simple",
     "packages": {


### PR DESCRIPTION
Add information such as version, readem and changelog to the final artifact. This should help track down the version that is currently being used with some nice info.