### PR TITLE
ci: enable submodule checkout in artifact workflow

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          submodules: recursive
 
       - name: Detect changed files
         id: changed-files
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Get commit info
         id: commit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
         if: ${{ steps.release.outputs.release_created }}
         with:
-          submodules: true
+          submodules: recursive
       - name: Build plugin package
         if: ${{ steps.release.outputs.release_created }}
         run: ./package.sh

--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,7 +11,8 @@ mkdir -p "$WORK_DIR/comicreader.koplugin"
 cp -r "$SCRIPT_DIR/src" "$WORK_DIR/comicreader.koplugin/src"
 cp "$SCRIPT_DIR/LICENSE.md" "$SCRIPT_DIR/version.txt" "$SCRIPT_DIR/CHANGELOG.md" "$SCRIPT_DIR/README.md" "$SCRIPT_DIR/main.lua" "$SCRIPT_DIR/_meta.lua" "$WORK_DIR/comicreader.koplugin/"
 
-cp -r "$SCRIPT_DIR/extra-plugins/statistics.koplugin" "$WORK_DIR/statistics.koplugin"
+mkdir -p "$WORK_DIR/statistics.koplugin"
+cp "$SCRIPT_DIR/extra-plugins/statistics.koplugin"/*.lua "$WORK_DIR/statistics.koplugin/"
 
 cd "$WORK_DIR"
 zip -r "$OUTPUT_DIR/comicreader.koplugin.zip" comicreader.koplugin statistics.koplugin


### PR DESCRIPTION
This change updates the build-artifact workflow to ensure git submodules are checked out during the build process.

- Adds `submodules: true` to the actions/checkout step
- Ensures all submodules are available for subsequent workflow steps

Change-Id: 9e0a899b0d59b9781898c46fe219b2e9
Change-Id-Short: qlzprqqozmuq
References: #55 