### PR TITLE
fix: prevent crash when files re-opened on single page mode state

### DIFF
--- a/src/readerpaging.lua
+++ b/src/readerpaging.lua
@@ -405,7 +405,7 @@ end
 --
 -- The early return guards against nil dereference to prevent crashes during initialization.
 function ReaderPaging:autoEnableDualPageModeIfLandscape()
-    if not self.document_settings or not self.reader_settings then
+    if not self.document_settings or not self.reader_settings or self.current_page == 0 then
         return
     end
 
@@ -441,7 +441,7 @@ end
 --
 -- The early return guards against nil dereference to prevent crashes during initialization.
 function ReaderPaging:disableDualPageModeIfNotLandscape()
-    if not self.document_settings then
+    if not self.document_settings or self.current_page == 0 then
         return
     end
 


### PR DESCRIPTION
This happens in a similar conditon what 525e3f6 fixes, but when document_settings and reader_settings are not nil.

- Add a check for when current_page is 0 in the early return guard.
- Prevent problematic page pair being retrieved, causing issues down the call stack when current_page is 0 and auto enable dual page is true