### PR TITLE
fix: _mate.lua name field

### DIFF
--- a/_meta.lua
+++ b/_meta.lua
@@ -1,6 +1,6 @@
 local _ = require("gettext")
 return {
-    name = "ComicReader",
+    name = "comcireader",
     fullname = _("ComicReader"),
     description = _([[Plugin for better comic reading.]]),
 }


### PR DESCRIPTION
The meta lua file name should be the same as the folder name to ensure that disabling works as expected.

Change-Id: 59f93c9e76c83eb27556bac062a71054
Change-Id-Short: uqkqwnqlstnr
Fixes: #66