### PR TITLE
fix: add version field

### DIFF
--- a/_meta.lua
+++ b/_meta.lua
@@ -3,4 +3,5 @@ return {
     name = "ComicReader",
     fullname = _("ComicReader"),
     description = _([[Plugin for better comic reading.]]),
+    version = "0.0.4", -- x-release-please-version
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,5 +6,11 @@
   "release-type": "simple",
   "packages": {
     ".": {}
-  }
+  },
+  "extra-files": [
+    {
+      "type": "generic",
+      "path": "_meta.lua"
+    }
+  ]
 }


### PR DESCRIPTION
Add a version field to _meta.lua and update release-please-config.json to ensure version changes are tracked in plugin metadata.

- Add version "0.0.4" to _meta.lua for accurate versioning
- Update release-please-config.json to include _meta.lua as extra file
- Keep plugin metadata and release process in sync

Change-Id: 2e9c9b8ed1744e3739fffc46dc7e44af
Change-Id-Short: xlqnqorlmysv
Fixes: #72